### PR TITLE
Clarification on how to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,6 @@ except ValidationException, e:
 
 # Developing and Contributing
 
-To run Schemer's tests, simply run `python setup.py nosetests` at the command line.
+To run Schemer's tests, simply install nose (`pip install nose`) and run `python setup.py nosetests` at the command line.
 
 All contributions submitted as GitHub pull requests are warmly received.


### PR DESCRIPTION
If nose isn't installed, you'll get an "invalid command 'nosetests' error".
