### PR TITLE
Dynamic schema functions previously could only be used to validate

### DIFF
--- a/schemer/__init__.py
+++ b/schemer/__init__.py
@@ -225,13 +225,12 @@ class Schema(object):
         # All fields should have a type
         field_type = field_spec['type']
         if isinstance(field_type, types.FunctionType):
-            if isinstance(value, dict):
+            try:
                 field_type = field_type(value)
-                if not isinstance(field_type, type) and not isinstance(field_type, Schema):
-                    raise SchemaFormatException("Dynamic schema function did not return a type at path {}", path)
-            else:
-                errors[path] = "Field type of function expects a value of type dict"
-                return
+            except Exception as e:
+                raise SchemaFormatException("Dynamic schema function raised exception: {}".format(str(e)), path)
+            if not isinstance(field_type, (type, Schema, Array)):
+                raise SchemaFormatException("Dynamic schema function did not return a type at path {}", path)
 
 
         # If our field is an embedded document, recurse into it

--- a/tests/schemer/sample.py
+++ b/tests/schemer/sample.py
@@ -36,6 +36,18 @@ def get_author_schema(document):
     else:
         return name_schema
 
+website_schema = Schema({
+    "url": {"type": basestring, "required": True},
+    "name": {"type": basestring, "required": True}
+    })
+
+def get_website_schema(document):
+    if isinstance(document, list):
+        return Array(website_schema)
+    elif isinstance(document, dict):
+        return website_schema
+    return basestring
+
 blog_post_schema = Schema({
     "author":           {"type": get_author_schema, "required": True},
     "content":          {"type": Schema({
@@ -53,7 +65,8 @@ blog_post_schema = Schema({
     "tags":             {"type": Array(basestring), "default": ["blog"], "validates": length(1)},
     "misc":             {"type": Mixed(basestring, int)},
     "linked_id":        {"type": Mixed(int, basestring)},
-    "external_code":    {"type": basestring, "nullable": False}
+    "external_code":    {"type": basestring, "nullable": False},
+    "website":          {"type": get_website_schema}
 })
 
 
@@ -87,7 +100,11 @@ def valid_doc(overrides=None):
             }
         ],
         "tags": ["cookies", "recipe", "yum"],
-        "external_code": "ABC123"
+        "external_code": "ABC123",
+        "website": {
+            "url": "johnhumphreys.tumblr.com",
+            "name": "John's Cooking Blog"
+        }
     }
     if overrides:
         doc.update(overrides)

--- a/tests/schemer/schema_test.py
+++ b/tests/schemer/schema_test.py
@@ -210,9 +210,11 @@ class TestBlogValidation(unittest.TestCase):
         self.document_1['external_code'] = None
         self.assert_document_paths_invalid(self.document_1, ['external_code'])
 
-    def test_incorrect_type(self):
+    def test_dynamic_function_exception(self):
         self.document_1['author'] = 33
-        self.assert_document_paths_invalid(self.document_1, ['author'])
+        with self.assertRaises(SchemaFormatException) as cm:
+            blog_post_schema.validate(self.document_1)
+        self.assertEqual('author', cm.exception.path)
 
     def test_mixed_type(self):
         self.document_1['misc'] = "a string"
@@ -259,6 +261,22 @@ class TestBlogValidation(unittest.TestCase):
     def test_validation_of_array(self):
         self.document_1['tags'] = []
         self.assert_document_paths_invalid(self.document_1, ['tags'])
+
+    def test_dynamic_function_valid_array(self):
+        self.document_1['website'] = [self.document_1['website'] for i in range(2)]
+        blog_post_schema.validate(self.document_1)
+
+    def test_dynamic_function_invalid_array(self):
+        self.document_1['website'] = ["string" for i in range(2)]
+        self.assert_document_paths_invalid(self.document_1, ['website.0', 'website.1'])
+
+    def test_dynamic_function_correct_type(self):
+        self.document_1['website'] = "WEB"
+        blog_post_schema.validate(self.document_1)
+
+    def test_dynamic_function_wrong_type(self):
+        self.document_1['website'] = 56
+        self.assert_document_paths_invalid(self.document_1, ['website'])
 
 
 class TestDefaultApplication(unittest.TestCase):


### PR DESCRIPTION
subdocuments of type dict.  They can now be used to validate the
subdocument against any type, including an Array of Schemas