### PR TITLE
Loosen restrictions on email validation

### DIFF
--- a/schemer/validators.py
+++ b/schemer/validators.py
@@ -109,13 +109,19 @@ def is_email():
     """
     Validates that a fields value is a valid email address.
     """
-    # Stolen from Django
-    regex = re.compile(
-        r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"  # dot-atom
-        # quoted-string, see also http://tools.ietf.org/html/rfc2822#section-3.2.5
-        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"'
-        r')@((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?$)'  # domain
-        r'|\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$', re.IGNORECASE)  # literal form, ipv4 address (SMTP 4.1.3)
+
+    part = (
+        ur'\b'          # Start part boundary
+        ur'(?!^\.)'     # Does not start with a dot
+        ur'(?!\.$)'     # Does not end with a dot
+        ur'(?!.*\.\.)'  # Does not have double dots anywhere
+        ur'\S+'         # One or more non-whitespace characters
+        ur'\b'          # End part boundary
+    )
+
+    email = ur'^{part}@{part}$'.format(part=part)
+
+    regex = re.compile(email, re.IGNORECASE | re.UNICODE)
 
     def validate(value):
         if not regex.match(value):

--- a/tests/schemer/validators_test.py
+++ b/tests/schemer/validators_test.py
@@ -135,12 +135,34 @@ class TestIsEmail(unittest.TestCase):
         self.validator = is_email()
 
     def test_valid(self):
-        self.assertIsNone(self.validator('s.balmer@hotmail.com'))
+        valid_emails = [
+            's.balmer@hotmail.com',
+            'a.dot@domain.com',
+            'a+plus@domain.com',
+            'at@at@domain.com',
+            'local@domain.newtld',
+            'local@domain.verylongtld',
+            'local@domain'
+        ]
+
+        for email in valid_emails:
+            self.assertIsNone(self.validator(email))
 
     def test_invalid(self):
-        self.assertEqual(
-            "'notanemail' is not a valid email address",
-            self.validator("notanemail"))
+        invalid_emails = [
+            '.start@dot.com',
+            'end.@dot.com',
+            'double..dot@dot.com',
+            'local@.start.com',
+            'local@end.',
+            'local@double..dot.com',
+            '@no.local',
+            'no.domain@',
+            'notanemail'
+        ]
+
+        for email in invalid_emails:
+            self.assertEqual(self.validator(email), "'{email}' is not a valid email address".format(email=email))
 
 
 class TestIsUrl(unittest.TestCase):


### PR DESCRIPTION
This changes the email validation to be less restrictive. The rules are:

For each part (includeing the local and domain parts)...
- Disallow a dot at the start (*NO* `.here@there.com`)
- Disallow a dot at the end (*NO* `red.@blue.com`)
- Disallow double "dots" anywhere (*NO* `in..fo@gc.com`)
- Require an `@`
- Ensure there is one or more non-whitepace character before and after the `@`